### PR TITLE
Add web view for LCA results

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -57,22 +57,26 @@ _logger = setup_ifclca_logger()
 
 # Import our modules - handle relative imports carefully
 if _BPY_AVAILABLE:
-    # Normal Blender imports
-    from . import panels
-    from . import operators
-    from . import properties
+    try:
+        from . import panels
+        from . import operators
+        from . import properties
+    except ImportError:
+        try:
+            import panels
+            import operators
+            import properties
+        except ImportError:
+            panels = None
+            operators = None
+            properties = None
 else:
-    # For testing, use absolute imports
     try:
         import panels
-        import operators  
+        import operators
         import properties
     except ImportError:
-        # If that fails, we're probably in a test environment
-        # where the modules aren't importable
-        panels = None
-        operators = None
-        properties = None
+        panels = operators = properties = None
 
 # Module reload support for development
 if _BPY_AVAILABLE and "bpy" in locals():

--- a/operators.py
+++ b/operators.py
@@ -656,6 +656,27 @@ class IFCLCA_OT_ExportResults(Operator):
             return {'CANCELLED'}
 
 
+# Simple web viewer -------------------------------------------------------
+
+class IFCLCA_OT_ViewWebResults(Operator):
+    """Launch a local web page to view results"""
+    bl_idname = "ifclca.view_web_results"
+    bl_label = "View Results in Browser"
+    bl_description = "Open a simple web page showing the analysis results"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    def execute(self, context):
+        from . import web_interface
+        props = context.scene.ifclca_props
+        if not props.results_text:
+            self.report({'ERROR'}, "No results available")
+            return {'CANCELLED'}
+
+        web_interface.update_results(props.results_text)
+        web_interface.start_server()
+        self.report({'INFO'}, "Web results opened in browser")
+        return {'FINISHED'}
+
 # List of classes to register
 classes = [
     IFCLCA_OT_LoadIFC,
@@ -664,5 +685,6 @@ classes = [
     IFCLCA_OT_RunAnalysis,
     IFCLCA_OT_ClearResults,
     IFCLCA_OT_AutoMapMaterials,
-    IFCLCA_OT_ExportResults
-] 
+    IFCLCA_OT_ExportResults,
+    IFCLCA_OT_ViewWebResults
+]

--- a/tests/test_web_interface.py
+++ b/tests/test_web_interface.py
@@ -1,0 +1,7 @@
+from web_interface import _get_html, update_results
+
+def test_update_results_and_html():
+    update_results('test data')
+    html = _get_html()
+    assert 'IfcLCA Results' in html
+    assert 'Loading' in html

--- a/web_interface.py
+++ b/web_interface.py
@@ -1,0 +1,80 @@
+import http.server
+import socketserver
+import threading
+import webbrowser
+import json
+from pathlib import Path
+
+_results_text = ""
+_server = None
+_thread = None
+PORT = 0
+
+class WebHandler(http.server.SimpleHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == '/api/results':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps({'results': _results_text}).encode('utf-8'))
+        elif self.path == '/' or self.path == '/index.html':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+            html = _get_html()
+            self.wfile.write(html.encode('utf-8'))
+        else:
+            super().do_GET()
+
+def _get_html():
+    html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='utf-8'/>
+    <title>IfcLCA Results</title>
+    <style>
+        body {{ font-family: Arial, sans-serif; margin: 2em; }}
+        pre {{ background: #f0f0f0; padding: 1em; }}
+    </style>
+</head>
+<body>
+    <h1>IfcLCA Results</h1>
+    <pre id='results'>Loading...</pre>
+    <script>
+        async function load() {{
+            const r = await fetch('/api/results');
+            const j = await r.json();
+            document.getElementById('results').textContent = j.results || 'No results';
+        }}
+        load();
+        setInterval(load, 2000);
+    </script>
+</body>
+</html>"""
+    return html
+
+def start_server(port: int = 0):
+    global _server, _thread, PORT
+    if _server:
+        return PORT
+    handler = WebHandler
+    _server = socketserver.TCPServer(('localhost', port), handler)
+    PORT = _server.server_address[1]
+    _thread = threading.Thread(target=_server.serve_forever, daemon=True)
+    _thread.start()
+    webbrowser.open(f'http://localhost:{PORT}/')
+    return PORT
+
+def stop_server():
+    global _server, _thread
+    if _server:
+        _server.shutdown()
+        _server.server_close()
+        _server = None
+    if _thread:
+        _thread.join()
+        _thread = None
+
+def update_results(text: str):
+    global _results_text
+    _results_text = text


### PR DESCRIPTION
## Summary
- enable fallback imports if Blender isn't packaged
- expose web view via `IFCLCA_OT_ViewWebResults` operator
- add minimal local web server
- test web server HTML generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d4e44e9048320a838975502997c5e