### PR TITLE
Add simple web interface for LCA results

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -58,9 +58,14 @@ _logger = setup_ifclca_logger()
 # Import our modules - handle relative imports carefully
 if _BPY_AVAILABLE:
     # Normal Blender imports
-    from . import panels
-    from . import operators
-    from . import properties
+    try:
+        from . import panels
+        from . import operators
+        from . import properties
+    except Exception:
+        import panels
+        import operators
+        import properties
 else:
     # For testing, use absolute imports
     try:

--- a/assets/web/index.html
+++ b/assets/web/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>IfcLCA Results</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+table { border-collapse: collapse; width: 100%; }
+th, td { border: 1px solid #ccc; padding: 8px; }
+th { background: #eee; cursor:pointer; }
+</style>
+</head>
+<body>
+<h1>IfcLCA Results</h1>
+<table id="results">
+<thead>
+<tr><th data-key="name">Material</th><th data-key="total_volume">Volume (m³)</th><th data-key="total_mass">Mass (kg)</th><th data-key="total_carbon">Carbon (kg CO₂e)</th></tr>
+</thead>
+<tbody></tbody>
+</table>
+<script>
+function load(){
+  fetch('/results').then(r=>r.json()).then(data=>{
+    const tbody=document.querySelector('#results tbody');
+    tbody.innerHTML='';
+    Object.entries(data).forEach(([name,info])=>{
+      const tr=document.createElement('tr');
+      tr.innerHTML=`<td>${name}</td><td>${info.total_volume.toFixed(2)}</td><td>${info.total_mass.toFixed(0)}</td><td>${info.total_carbon.toFixed(1)}</td>`;
+      tbody.appendChild(tr);
+    });
+  });
+}
+function sortTable(key){
+  const rows=Array.from(document.querySelectorAll('#results tbody tr'));
+  const idx={name:0,total_volume:1,total_mass:2,total_carbon:3}[key];
+  rows.sort((a,b)=>parseFloat(b.children[idx].textContent)-parseFloat(a.children[idx].textContent));
+  const tbody=document.querySelector('#results tbody');
+  tbody.innerHTML='';
+  rows.forEach(r=>tbody.appendChild(r));
+}
+document.querySelectorAll('th').forEach(th=>{
+  th.addEventListener('click',()=>sortTable(th.dataset.key));
+});
+load();
+</script>
+</body>
+</html>

--- a/panels.py
+++ b/panels.py
@@ -349,6 +349,7 @@ class IFCLCA_PT_AnalysisPanel(Panel):
             row = col.row(align=True)
             row.operator("ifclca.clear_results", text="Clear", icon='X')
             row.operator("ifclca.export_results", text="Export", icon='EXPORT')
+            row.operator("ifclca.view_web_results", text="Web", icon='WORLD')
     
     def _parse_carbon_value(self, carbon_str):
         """Parse carbon value from string like '31.59 t CO₂-eq' or '669.7 kg CO₂-eq'"""

--- a/properties.py
+++ b/properties.py
@@ -108,6 +108,12 @@ class IfcLCAProperties(PropertyGroup):
         description="Formatted results text",
         default=""
     )
+    results_json: StringProperty(
+        name="Results JSON",
+        description="Analysis results in JSON",
+        default="",
+    )
+
     
     show_results: BoolProperty(
         name="Show Results",

--- a/tests/test_web_interface.py
+++ b/tests/test_web_interface.py
@@ -1,0 +1,18 @@
+import json
+import urllib.request
+import time
+
+from web_interface import start_server
+
+
+def test_web_server_serves_results():
+    data = {"Mat": {"total_volume": 1.0, "total_mass": 2.0, "total_carbon": 3.0}}
+    server = start_server(data, port=0)
+    port = server.server_address[1]
+    # Allow server to start
+    time.sleep(0.1)
+    with urllib.request.urlopen(f"http://localhost:{port}/results") as resp:
+        body = resp.read().decode()
+    server.shutdown()
+    received = json.loads(body)
+    assert received == data

--- a/web_interface.py
+++ b/web_interface.py
@@ -1,0 +1,39 @@
+import http.server
+import socketserver
+import threading
+import webbrowser
+import json
+from pathlib import Path
+
+WEB_DIR = Path(__file__).parent / 'assets' / 'web'
+
+class ResultsHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, results=None, **kwargs):
+        self.results = results or {}
+        super().__init__(*args, directory=str(WEB_DIR), **kwargs)
+
+    def do_GET(self):
+        if self.path.rstrip('/') == '/results':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(self.results).encode('utf-8'))
+        else:
+            super().do_GET()
+
+def start_server(results, port=0):
+    handler = lambda *args, **kwargs: ResultsHandler(*args, results=results, **kwargs)
+    httpd = socketserver.TCPServer(('localhost', port), handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd
+
+def launch_results_browser(results):
+    server = start_server(results)
+    port = server.server_address[1]
+    url = f'http://localhost:{port}/index.html'
+    try:
+        webbrowser.open(url)
+    except Exception:
+        pass
+    return server


### PR DESCRIPTION
## Summary
- store LCA results in JSON in addon properties
- add operator to launch results in browser via a simple HTTP server
- expose 'View in Browser' button in the analysis panel
- include minimal web server utilities and HTML page
- test the web server functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d4e8f873883208c17b948e17deb53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive web-based results viewer for IfcLCA analysis, allowing users to view, sort, and explore detailed results in their browser.
  - Added a "Web" button to the analysis panel for easy access to the web viewer.
- **Bug Fixes**
  - Improved module import robustness to handle different runtime contexts.
- **Tests**
  - Added tests to verify that the web server correctly serves analysis results.
- **Chores**
  - Added new properties to store analysis results in JSON format for enhanced interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->